### PR TITLE
Fix for Sphinx 5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.7"
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install tox and other packages
+        run: pip install tox
+
+      - name: Run tox
+        run: tox

--- a/sphinxcontrib/trimblank.py
+++ b/sphinxcontrib/trimblank.py
@@ -95,7 +95,7 @@ class TrimblankVisitor(nodes.GenericNodeVisitor):
                 self._logger.info(
                     '\nBefore : %s\nAfter  : %s',
                     child.astext(), new_txt, location=child)
-            node.replace(child, nodes.Text(new_txt, child.astext()))
+            node.replace(child, nodes.Text(new_txt))
 
 
 def get_bool_value(config, builder_name):

--- a/sphinxcontrib/trimblank.py
+++ b/sphinxcontrib/trimblank.py
@@ -95,7 +95,7 @@ class TrimblankVisitor(nodes.GenericNodeVisitor):
                 self._logger.info(
                     '\nBefore : %s\nAfter  : %s',
                     child.astext(), new_txt, location=child)
-            node.replace(child, nodes.Text(new_txt, child.rawsource))
+            node.replace(child, nodes.Text(new_txt, child.astext()))
 
 
 def get_bool_value(config, builder_name):

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37
+envlist = py{37,38,39,310}-sphinx{3,4,5}
 
 [testenv]
 deps =
-    -rrequirements.txt
+    sphinx5: Sphinx>=5.0,<6.0
+    sphinx4: Sphinx>=4.0,<5.0
+    sphinx3: Sphinx>=3.0,<4.0
 commands =
     python -m unittest discover


### PR DESCRIPTION
`sphinxcontrib-trimblank` does not work with Sphinx 5. This PR should fix that. It would be great if you could accept this (I'm using it in my job.)

As far as I see, the direct cause of the problem was the incompatibility between `docutils` used by Sphinx 4 and 5. Although, according to a warning message emitted from the unit test, this fix should be somehow ad-hoc... but it works for now.

In addition to fix the problem, I defined GitHub Action to show that the fix actually works in various configurations. As it's not essential, I will remove the change from this PR if you don't like it. In that case, just put a comment here.

edit: The test result of 2b5c8f0 should be accessible [here](https://github.com/sgryjp/sphinxcontrib-trimblank/runs/6814983514?check_suite_focus=true).